### PR TITLE
Update wavetest.py

### DIFF
--- a/lib/waipy/cwt/wavetest.py
+++ b/lib/waipy/cwt/wavetest.py
@@ -164,13 +164,9 @@ def wavelet(Y, dt, param, dj, s0, j1, mother, J1=None):
     # simetric eqn 5
     # k = np.arange(n / 2)
 
-    k_pos, k_neg = [], []
-    for i in np.arange(0, int(n / 2)):
-        k_pos.append(i * ((2 * math.pi) / (n * dt)))  # frequencies as in eqn5
-        k_neg = k_pos[::-1]  # inversion vector
-        k_neg = [e * (-1) for e in k_neg]  # negative part
-        # delete the first value of k_neg = last value of k_pos
-        # k_neg = k_neg[1:-1]
+    k_pos = np.arange(0, n // 2)  * ((2 * np.pi) / (n * dt))
+    k_neg = -k_pos[::-1]
+    
     k = np.concatenate((k_pos, k_neg), axis=0)  # vector of symmetric
     # compute fft of the padded time series
     f = np.fft.fft(x, n)


### PR DESCRIPTION
Replaced bottleneck with logically equivalent code. There's a section in the code which appears to be useless, and is causing significant performance issues with large time series.

In line 169: k_pos is independent of k_neg: therefore we may just replace it with its final value.

Lines 170/171 overwrite k_neg every pass. Therefore, the final value of k_neg only depends on the final value of k_pos.

I was taking a significant performance hit for time series of length > 100,000. It's obvious now from the code why: the for loop (line 168) is linear in the time series length, and unnecessarily allocates/deallocates memory repeatedly, with O(n^2) memory used, since the length of k_neg is the same as the iterator i. The exact value is something like (n / 2) (n /2 + 1) / 2 excess memory operations.