### PR TITLE
resolved the issue of math module not found

### DIFF
--- a/lib/waipy/cwa/cross_wavelet.py
+++ b/lib/waipy/cwa/cross_wavelet.py
@@ -16,7 +16,7 @@ import numpy as np
 import pylab
 from pylab import *
 import matplotlib.pyplot as plt
-import cmath
+import math
 import pandas as pd
 
 


### PR DESCRIPTION
This change resolves the NameError: name 'math' is not defined which was occurring when plot_cross() or plot_cohere were called. 
Signed-off-by: Ayush1271 <ayushranjan1271@gmail.com>